### PR TITLE
Fix failure on deploying RKE2

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -25,7 +25,7 @@ func Command(k8sVersion string) string {
 	kubectl := "/usr/local/bin/kubectl"
 	runtime := config.GetRuntime(k8sVersion)
 	if runtime == config.RuntimeRKE2 {
-		kubectl = "/var/lib/rancher/rke2/bin"
+		kubectl = "/var/lib/rancher/rke2/bin/kubectl"
 	}
 	return kubectl
 }

--- a/pkg/rancher/wait.go
+++ b/pkg/rancher/wait.go
@@ -31,7 +31,7 @@ func ToWaitRancherWebhookInstruction(imageOverride, systemDefaultRegistry, k8sVe
 		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
 	}
 	return &applyinator.Instruction{
-		Name:       "wait-rancher",
+		Name:       "wait-rancher-webhook",
 		SaveOutput: true,
 		Image:      images.GetInstallerImage(imageOverride, systemDefaultRegistry, k8sVersion),
 		Args:       []string{"retry", kubectl.Command(k8sVersion), "-n", "cattle-system", "rollout", "status", "-w", "deploy/rancher-webhook"},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -182,7 +182,7 @@ func GetManifests(runtime config.Runtime) string {
 
 func ToInstruction(imageOverride, systemDefaultRegistry, k8sVersion, dataDir string) (*applyinator.Instruction, error) {
 	bootstrap := GetBootstrapManifests(dataDir)
-	kubectl := kubectl.Command(k8sVersion)
+	kubectlCmd := kubectl.Command(k8sVersion)
 
 	cmd, err := self.Self()
 	if err != nil {
@@ -192,7 +192,8 @@ func ToInstruction(imageOverride, systemDefaultRegistry, k8sVersion, dataDir str
 		Name:       "bootstrap",
 		SaveOutput: true,
 		Image:      images.GetInstallerImage(imageOverride, systemDefaultRegistry, k8sVersion),
-		Args:       []string{"retry", kubectl, "apply", "--validate=false", "-f", bootstrap},
+		Args:       []string{"retry", kubectlCmd, "apply", "--validate=false", "-f", bootstrap},
+		Env:        kubectl.Env(k8sVersion),
 		Command:    cmd,
 	}, nil
 }

--- a/pkg/runtime/role.go
+++ b/pkg/runtime/role.go
@@ -23,9 +23,11 @@ var (
 )
 
 func ToBootstrapFile(runtime config.Runtime) (*applyinator.File, error) {
-	data, err := json.Marshal(map[string]interface{}{
-		"cluster-init": "true",
-	})
+	bootstrapConfig := map[string]interface{}{}
+	if runtime == config.RuntimeK3S {
+		bootstrapConfig["cluster-init"] = "true"
+	}
+	data, err := json.Marshal(bootstrapConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The PR contains fixes to make RKE2 deployment work.

- Remove unsupported RKE2 config `cluster-init`.
- Fix kubectl binary name.
- Provide runtime env when applying resources.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>