### PR TITLE
Allow roles to publish configuration info

### DIFF
--- a/pkg/runtime/role.go
+++ b/pkg/runtime/role.go
@@ -54,9 +54,7 @@ func ToConfig(config *config.RuntimeConfig, clusterInit bool) ([]byte, error) {
 		config.ConfigValues,
 	}
 
-	if clusterInit {
-		configObjects = append(configObjects, config)
-	}
+	configObjects = append(configObjects, config)
 
 	result := map[string]interface{}{}
 	for _, data := range configObjects {
@@ -66,6 +64,9 @@ func ToConfig(config *config.RuntimeConfig, clusterInit bool) ([]byte, error) {
 		}
 		delete(data, "extraConfig")
 		delete(data, "role")
+		if !clusterInit {
+			delete(data, "token")
+		}
 		for oldKey, newKey := range normalizeNames {
 			value, ok := data[oldKey]
 			if !ok {


### PR DESCRIPTION
## Changes 
This is for [issue 4](https://github.com/rancher/rancherd/issues/4)
This allows roles other than `cluster-init` to publish config information.
Token information is removed from non-cluster-init roles.
Signed-off-by: dereknola <derek.nola@suse.com>

## Verification
Agent nodes now show node-label needed for harvester 
```
root@node-2-buster64:/home/vagrant# cat /etc/rancher/rancherd/config.yaml 
server: https://172.10.2.101:8443
role: agent
token: '12345'
kubernetesVersion: v1.21.4+rke2r2
labels:
- harvesterhci.io/managed=true
root@node-2-buster64:/home/vagrant# cat /etc/rancher/rke2/config.yaml.d/40-rancherd.yaml
node-label:
- harvesterhci.io/managed=true
```