### PR TITLE
fix(certs): auto-install ca retrieved from rancher

### DIFF
--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -180,7 +180,7 @@ func ToFile(server, token string) (*applyinator.File, error) {
 
 	return &applyinator.File{
 		Content:     base64.StdEncoding.EncodeToString(cacert),
-		Path:        "/etc/pki/trust/anchors/additional-ca.pem",
+		Path:        "/etc/pki/trust/anchors/embedded-rancher-ca.pem",
 		Permissions: "0644",
 	}, nil
 }

--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/rancher/rancherd/pkg/tpm"
+	"github.com/rancher/system-agent/pkg/applyinator"
 	"github.com/rancher/wrangler/pkg/randomtoken"
 )
 
@@ -159,6 +160,29 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 	}
 
 	return data, hashHex(data), nil
+}
+
+func ToUpdateCACertificatesInstruction() (*applyinator.Instruction, error) {
+	cmd := "update-ca-certificates"
+
+	return &applyinator.Instruction{
+		Name:       "update-ca-certificates",
+		SaveOutput: true,
+		Command:    cmd,
+	}, nil
+}
+
+func ToFile(server, token string) (*applyinator.File, error) {
+	cacert, _, err := CACerts(server, token, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &applyinator.File{
+		Content:     base64.StdEncoding.EncodeToString(cacert),
+		Path:        "/etc/pki/trust/anchors/additional-ca.pem",
+		Permissions: "0644",
+	}, nil
 }
 
 func hashHex(token []byte) string {

--- a/pkg/plan/bootstrap.go
+++ b/pkg/plan/bootstrap.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rancher/system-agent/pkg/applyinator"
 
+	"github.com/rancher/rancherd/pkg/cacerts"
 	"github.com/rancher/rancherd/pkg/config"
 	"github.com/rancher/rancherd/pkg/discovery"
 	"github.com/rancher/rancherd/pkg/join"
@@ -50,7 +51,13 @@ func toJoinPlan(cfg *config.Config, dataDir string) (*applyinator.Plan, error) {
 	}
 
 	plan := plan{}
+	if err := plan.addFile(cacerts.ToFile(cfg.Server, cfg.Token)); err != nil {
+		return nil, err
+	}
 	if err := plan.addFile(join.ToScriptFile(cfg, dataDir)); err != nil {
+		return nil, err
+	}
+	if err := plan.addInstruction(cacerts.ToUpdateCACertificatesInstruction()); err != nil {
 		return nil, err
 	}
 	if err := plan.addInstruction(join.ToInstruction(cfg, dataDir)); err != nil {
@@ -202,6 +209,7 @@ func (p *plan) addFiles(cfg *config.Config, dataDir string) error {
 
 	// rancher values.yaml
 	return p.addFile(rancher.ToFile(cfg, dataDir))
+
 }
 
 func (p *plan) addFile(file *applyinator.File, err error) error {

--- a/pkg/rancher/wait.go
+++ b/pkg/rancher/wait.go
@@ -44,7 +44,7 @@ func ToWaitSUCInstruction(imageOverride, systemDefaultRegistry, k8sVersion strin
 		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
 	}
 	return &applyinator.Instruction{
-		Name:       "wait-rancher-webhook",
+		Name:       "wait-system-upgrade-controller",
 		SaveOutput: true,
 		Args:       []string{"retry", kubectl.Command(k8sVersion), "-n", "cattle-system", "rollout", "status", "-w", "deploy/system-upgrade-controller"},
 		Env:        kubectl.Env(k8sVersion),


### PR DESCRIPTION
Add the following two items to the existing joining plan of rancherd:

- File: the CA cert downloaded from the embedded Rancher Manager (the endpoint is `https://<VIP/FQDN>/cacerts`)
- Instruction: `update-ca-certificates` command

During the Harvester bootstrap, rancherd will process the plan, try to get the CA cert, and update the system's trust list.

Related issue: harvester/harvester#4603