### PR TITLE
instructions to patch local cluster resource for v2.8.1

### DIFF
--- a/pkg/plan/bootstrap.go
+++ b/pkg/plan/bootstrap.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/rancher/system-agent/pkg/applyinator"
 
@@ -134,8 +135,11 @@ func (p *plan) addInstructions(cfg *config.Config, dataDir string) error {
 		return err
 	}
 
-	if err := p.addInstruction(rancher.PatchLocalProvisioningClusterStatus(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
-		return err
+	// currently instruction is only needed for v2.8.x
+	if strings.HasPrefix(cfg.RancherVersion, "v2.8") {
+		if err := p.addInstruction(rancher.PatchLocalProvisioningClusterStatus(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
+			return err
+		}
 	}
 
 	if err := p.addInstruction(rancher.ToWaitSUCInstruction(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {

--- a/pkg/plan/bootstrap.go
+++ b/pkg/plan/bootstrap.go
@@ -134,6 +134,10 @@ func (p *plan) addInstructions(cfg *config.Config, dataDir string) error {
 		return err
 	}
 
+	if err := p.addInstruction(rancher.PatchLocalProvisioningClusterStatus(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
+		return err
+	}
+
 	if err := p.addInstruction(rancher.ToWaitSUCInstruction(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
 		return err
 	}

--- a/pkg/rancher/wait.go
+++ b/pkg/rancher/wait.go
@@ -123,3 +123,19 @@ func ToScaleUpFleetControllerInstruction(imageOverride, systemDefaultRegistry, k
 		Command:    cmd,
 	}, nil
 }
+
+// Needs to patch status subresource
+// k patch cluster.provisioning local -n fleet-local --subresource=status --type=merge --patch '{"status":{"fleetWorkspaceName": "fleet-local"}}'
+func PatchLocalProvisioningClusterStatus(imageOverride, systemDefaultRegistry, k8sVersion string) (*applyinator.Instruction, error) {
+	cmd, err := self.Self()
+	if err != nil {
+		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
+	}
+	return &applyinator.Instruction{
+		Name:       "wait-suc-plan-resolved",
+		SaveOutput: true,
+		Args:       []string{"retry", kubectl.Command(k8sVersion), "-n", "fleet-local", "patch", "cluster.provisioning", "local", "--subresource=status", "--type=merge", "--patch", "{\"status\":{\"fleetWorkspaceName\": \"fleet-local\"}}"},
+		Env:        kubectl.Env(k8sVersion),
+		Command:    cmd,
+	}, nil
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -102,6 +102,9 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 			"metadata": map[string]interface{}{
 				"name":      "local",
 				"namespace": "fleet-local",
+				"labels": map[string]interface{}{
+					"provisioning.cattle.io/management-cluster-name": "local",
+				},
 			},
 			"spec": map[string]interface{}{
 				"kubernetesVersion": k8sVersion,


### PR DESCRIPTION
PR introduces minor changes which include:

* additional label on local cluster.provisioning object to allow to be reconciled by rancher
* additional command to run check for local cluster and patch cluster status.