### PR TITLE
ci: remove dapper container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,13 @@ jobs:
   build:
     name: Build images
     runs-on: ubuntu-latest
-    container:
-      image: rancher/dapper:v0.6.0
     steps:
-    # Git is not in Dapper container image. Add it manually for dirty check.
-    - name: Add Git
-      run: apk add -U git
     - name: Checkout code
       uses: actions/checkout@v4
 
     # Build binaries and SHA files
-    - name: Run dapper ci
-      run: dapper ci
+    - name: Run make ci
+      run: make ci
 
     - name: Release
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
In dapper container, `gh` command is not found.

https://github.com/rancher/rancherd/actions/runs/13256180358/job/37003355603