### PR TITLE
feat: add config.nodeName to joiner

### DIFF
--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -59,6 +59,10 @@ func ToInstruction(config *config.Config, dataDir string) (*applyinator.Instruct
 	env = addEnv(env, "CATTLE_ROLE_CONTROLPLANE", fmt.Sprint(controlPlane))
 	env = addEnv(env, "CATTLE_ROLE_WORKER", fmt.Sprint(worker))
 
+	if config.NodeName != "" {
+		env = addEnv(env, "CATTLE_NODE_NAME", config.NodeName)
+	}
+
 	return &applyinator.Instruction{
 		Name:       "join",
 		SaveOutput: true,


### PR DESCRIPTION
### Description

Currently, when we create the first node, we can give the customized node name (`config.noddeName`) here.

https://github.com/rancher/rancherd/blob/6f7255eb0eafd3294e3ec5140d617ff1831b0b9b/pkg/resources/resources.go#L54-L62

But, for the joiner, we don't have a chance to give the `config.nodeName` to it.

https://github.com/rancher/rancherd/blob/6f7255eb0eafd3294e3ec5140d617ff1831b0b9b/pkg/join/join.go#L49-L62

### Solution

Add new env `CATTLE_NODE_NAME` for the joiner if `config.nodeName` is set.

### Related Issue

https://github.com/harvester/harvester/issues/7312