### PR TITLE
fix(plan): return err if one-time instruction fails

### DIFF
--- a/pkg/plan/run.go
+++ b/pkg/plan/run.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -46,6 +47,12 @@ func RunWithKubernetesVersion(ctx context.Context, k8sVersion string, plan *appl
 	})
 	if err != nil {
 		return err
+	}
+
+	// Explicitly check if one-time instruction executions fail because the plan
+	// execution above will not error upon such cases.
+	if !output.OneTimeApplySucceeded {
+		return errors.New("one-time instruction executions failed")
 	}
 
 	return saveOutput(output.OneTimeOutput, dataDir)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Even if any of the one-time instructions do not complete successfully, the entire plan execution still ends successfully (the returned `err` is `nil`). This results in RancherD being unable to retry, and the joining nodes remain unjoined.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Return an error when there are any one-time instruction execution failure so that RancherD can further retry.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#9886

#### Test plan:
<!-- Describe the test plan by steps. -->

See harvester/harvester#9886. It could be hard to reproduce/test whether the fix works.

#### Additional documentation or context
