### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 # check=skip=InvalidDefaultArgInFrom
 
-FROM golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 AS golangci-lint-bin
+FROM golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60 AS golangci-lint-bin
 
-FROM registry.suse.com/bci/golang:1.25.7 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 ARG MK_HOST_ARCH
 ENV ARCH=$MK_HOST_ARCH
 RUN zypper in -y bash git gcc docker vim less file curl wget ca-certificates trousers-devel

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/rancherd
 
-go 1.25.7
+go 1.26
 
 replace (
 	k8s.io/api => k8s.io/api v0.34.5


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
bump golang 1.26

#### Solution:
bump golang 1.26

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10734

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
