### PR TITLE
enhance: cacerts 502 error with troubleshooting guidance

### DIFF
--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -20,6 +20,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	rke2NodeTokenPath  = "/var/lib/rancher/rke2/server/node-token"
+	rancherdConfigPath = "/oem/90_custom.yaml"
+	rancherdAltConfig  = "/etc/rancher/rancherd/config.yaml"
+)
+
 var insecureClient = &http.Client{
 	Timeout: time.Second * 5,
 	Transport: &http.Transport{
@@ -169,10 +175,13 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 
 func cacertsResponseError(statusCode int, status string, data []byte) error {
 	if statusCode == http.StatusBadGateway {
-		return fmt.Errorf("failed to authenticate %d: %s (likely token mismatch or incorrect server URL)\n"+
-			"Verify cluster token matches /var/lib/rancher/rke2/server/node-token on management node\n"+
-			"Check token configuration in /oem/90_custom.yaml or /etc/rancher/rancherd/config.yaml\n"+
-			"Response: %s", statusCode, status, data)
+		return fmt.Errorf("failed to get cacerts (HTTP %d %s): likely token mismatch or incorrect server URL; "+
+			"verify cluster token matches %s on management node; "+
+			"check token configuration in %s or %s; "+
+			"response: %s",
+			statusCode, status,
+			rke2NodeTokenPath, rancherdConfigPath, rancherdAltConfig,
+			data)
 	}
 	return fmt.Errorf("response %d: %s getting cacerts: %s", statusCode, status, data)
 }

--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -151,7 +151,7 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("response %d: %s getting cacerts: %s", resp.StatusCode, resp.Status, data)
+		return nil, "", cacertsResponseError(resp.StatusCode, resp.Status, data)
 	}
 
 	if resp.Header.Get("X-Cattle-Hash") != hash(token, nonce, data) {
@@ -165,6 +165,16 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 	}
 
 	return data, hashHex(data), nil
+}
+
+func cacertsResponseError(statusCode int, status string, data []byte) error {
+	if statusCode == http.StatusBadGateway {
+		return fmt.Errorf("failed to authenticate %d: %s (likely token mismatch or incorrect server URL)\n"+
+			"Verify cluster token matches /var/lib/rancher/rke2/server/node-token on management node\n"+
+			"Check token configuration in /oem/90_custom.yaml or /etc/rancher/rancherd/config.yaml\n"+
+			"Response: %s", statusCode, status, data)
+	}
+	return fmt.Errorf("response %d: %s getting cacerts: %s", statusCode, status, data)
 }
 
 func ToUpdateCACertificatesInstruction() (*applyinator.OneTimeInstruction, error) {

--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -175,11 +175,11 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 
 func cacertsResponseError(statusCode int, status string, data []byte) error {
 	if statusCode == http.StatusBadGateway {
-		return fmt.Errorf("failed to get cacerts (HTTP %d %s): likely token mismatch or incorrect server URL; "+
-			"verify cluster token matches %s on management node; "+
+		return fmt.Errorf("failed to get cacerts (HTTP %s): likely token mismatch or incorrect server URL; "+
+			"verify the provided token matches %s on the server node; "+
 			"check token configuration in %s or %s; "+
 			"response: %s",
-			statusCode, status,
+			status,
 			rke2NodeTokenPath, rancherdConfigPath, rancherdAltConfig,
 			data)
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
https://github.com/rancher/rancher/blob/main/pkg/cacerts/handler.go#L54 does not check the cert length, hence it broken and finally return 502.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Quick workaround to help user is to improve error messages

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10685

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Get real token from node01: cat /var/lib/rancher/rke2/server/node-token → use part after last :
2. Join node02 with wrong token
3. See: `likely token mismatch or incorrect server URL ` in the log

#### Additional documentation or context
