### PR TITLE
fix: adapt the CRT and management Cluster for Rancher v2.15.0

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -88,6 +88,17 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 		},
 	}, v1.GenericMap{
 		Data: map[string]interface{}{
+			"kind":       "Cluster",
+			"apiVersion": "management.cattle.io/v3",
+			"metadata": map[string]interface{}{
+				"name": "local",
+				"annotations": map[string]interface{}{
+					"provisioning.cattle.io/administrated": "true",
+				},
+			},
+		},
+	}, v1.GenericMap{
+		Data: map[string]interface{}{
 			"kind":       "Secret",
 			"apiVersion": "v1",
 			"metadata": map[string]interface{}{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -102,17 +102,15 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 		},
 	}, v1.GenericMap{
 		Data: map[string]interface{}{
-			"kind":       "ClusterRegistrationToken",
-			"apiVersion": "management.cattle.io/v3",
+			"kind":       "Secret",
+			"apiVersion": "v1",
 			"metadata": map[string]interface{}{
-				"name":      "default-token",
+				"name":      "crt-token-default-token",
 				"namespace": "local",
 			},
-			"spec": map[string]interface{}{
-				"clusterName": "local",
-			},
-			"status": map[string]interface{}{
-				"token": token,
+			"type": "Opaque",
+			"data": map[string]interface{}{
+				"token": []byte(token),
 			},
 		},
 	}, v1.GenericMap{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -50,7 +51,7 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 	}
 
 	resources := config.Resources
-	return ToFile(append(resources, v1.GenericMap{
+	resources = append(resources, v1.GenericMap{
 		Data: map[string]interface{}{
 			"kind":       "Node",
 			"apiVersion": "v1",
@@ -88,17 +89,6 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 		},
 	}, v1.GenericMap{
 		Data: map[string]interface{}{
-			"kind":       "Cluster",
-			"apiVersion": "management.cattle.io/v3",
-			"metadata": map[string]interface{}{
-				"name": "local",
-				"annotations": map[string]interface{}{
-					"provisioning.cattle.io/administrated": "true",
-				},
-			},
-		},
-	}, v1.GenericMap{
-		Data: map[string]interface{}{
 			"kind":       "Secret",
 			"apiVersion": "v1",
 			"metadata": map[string]interface{}{
@@ -113,19 +103,6 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 		},
 	}, v1.GenericMap{
 		Data: map[string]interface{}{
-			"kind":       "Secret",
-			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
-				"name":      "crt-token-default-token",
-				"namespace": "local",
-			},
-			"type": "Opaque",
-			"data": map[string]interface{}{
-				"token": []byte(token),
-			},
-		},
-	}, v1.GenericMap{
-		Data: map[string]interface{}{
 			"apiVersion": "catalog.cattle.io/v1",
 			"kind":       "ClusterRepo",
 			"metadata": map[string]interface{}{
@@ -135,7 +112,65 @@ func ToBootstrapFile(config *config.Config, path string) (*applyinator.File, err
 				"url": "https://releases.rancher.com/server-charts/stable",
 			},
 		},
-	}), path)
+	})
+
+	// Rancher save CRT token into an underlying secret since v2.15.0
+	// As a result, we have to update the secret direct to set the token
+	// This could be changed in the future version of Rancher
+	// https://github.com/rancher/rancher/issues/56071#issuecomment-5168624729
+	if semver.Compare(config.RancherVersion, "v2.15.0") >= 0 {
+		resources = append(resources, v1.GenericMap{
+			Data: map[string]interface{}{
+				"kind":       "Secret",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name":      "crt-token-default-token",
+					"namespace": "local",
+				},
+				"type": "Opaque",
+				"data": map[string]interface{}{
+					"token": []byte(token),
+				},
+			},
+		})
+	} else {
+		resources = append(resources, v1.GenericMap{
+			Data: map[string]interface{}{
+				"kind":       "ClusterRegistrationToken",
+				"apiVersion": "management.cattle.io/v3",
+				"metadata": map[string]interface{}{
+					"name":      "default-token",
+					"namespace": "local",
+				},
+				"spec": map[string]interface{}{
+					"clusterName": "local",
+				},
+				"status": map[string]interface{}{
+					"token": token,
+				},
+			},
+		})
+	}
+
+	// Since Rancher v2.15.0, this annotation is needed on management cluster
+	// such that the cluster can be marked ready.
+	// https://github.com/rancher/rancher/blob/5221238cb9d8413e5fee60bc79fa911edac82a8a/pkg/capr/configserver/identity.go#L83-L95
+	if semver.Compare(config.RancherVersion, "v2.15.0") >= 0 {
+		resources = append(resources, v1.GenericMap{
+			Data: map[string]interface{}{
+				"kind":       "Cluster",
+				"apiVersion": "management.cattle.io/v3",
+				"metadata": map[string]interface{}{
+					"name": "local",
+					"annotations": map[string]interface{}{
+						"provisioning.cattle.io/administrated": "true",
+					},
+				},
+			},
+		})
+	}
+
+	return ToFile(resources, path)
 }
 
 func ToHarvesterClusterRepoFile(path string) (*applyinator.File, error) {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

While validating the PR https://github.com/harvester/harvester/pull/11167, we found 2 issues

- node couldn't join: rancherd shows the following errors
```
Jul 31 02:23:52 harvester-node-1 rancherd[1992]: time="2026-07-31T02:23:52Z" level=info msg="Bootstrapping Rancher (v2.15.0/v1.36.2+rke2r1)"
Jul 31 02:23:52 harvester-node-1 rancherd[1992]: time="2026-07-31T02:23:52Z" level=info msg="failed to bootstrap system, will retry: generating plan: response hash () does not match (vhJTIhdANJPI1wIax+ljQbKISKTXHUsd2jO2WXSh9GPN6Nmsg/C5f8v07e6YPCR1GmMQWoK5MUnxo55qnCaCCw==)"
Jul 31 02:24:07 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:07Z" level=info msg="Loading config file [/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml]"
Jul 31 02:24:07 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:07Z" level=info msg="Loading config file [/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap-repo.yaml]"
Jul 31 02:24:07 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:07Z" level=info msg="Loading config file [/etc/rancher/rancherd/config.yaml]"
Jul 31 02:24:07 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:07Z" level=info msg="Bootstrapping Rancher (v2.15.0/v1.36.2+rke2r1)"
Jul 31 02:24:07 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:07Z" level=info msg="failed to bootstrap system, will retry: generating plan: response hash () does not match (KsGv6OxUsBmHE3WWJk8w1V9/pGfpwu7fB6BrujRGhofFqw2ihSS6bKzy7vIRkeWATxKENIqBdr1noTObqy9VlQ==)"
Jul 31 02:24:22 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:22Z" level=info msg="Loading config file [/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml]"
Jul 31 02:24:22 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:22Z" level=info msg="Loading config file [/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap-repo.yaml]"
Jul 31 02:24:22 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:22Z" level=info msg="Loading config file [/etc/rancher/rancherd/config.yaml]"
Jul 31 02:24:22 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:22Z" level=info msg="Bootstrapping Rancher (v2.15.0/v1.36.2+rke2r1)"
Jul 31 02:24:22 harvester-node-1 rancherd[1992]: time="2026-07-31T02:24:22Z" level=info msg="failed to bootstrap system, will retry: generating plan: response hash () does not match (hWiaOrZH83U6lfDWkHjMrTiJlOKMwzrPNayPa4JSzCfNkeCSIJ++z4V8HEM2b3RAoOZC5nd1w6CRXEAY6IQFHw==)"
```

- first node rancherd stuck
```
level=error msg=\"will retry failed command [/var/lib/rancher/rke2/bin/kubectl -n fleet-local wait --for=condition=Provisioned=true [clusters.provisioning.cattle.io](http://clusters.provisioning.cattle.io/) local]: exit status 1\""
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- To set the token, patch the backing Secret of CRT
- Set annotation `provisioning.cattle.io/administrated: true` to the management cluster.


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10732
https://github.com/harvester/harvester/issues/11336


#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

https://suse.slack.com/archives/C0508UA84RF/p1785722048632579

Thanks for the help from @starbops @ibrokethecloud @bk201 @Vicente-Cheng !

