### PR TITLE
fix: to prevent TLS certificate flapping

### DIFF
--- a/pkg/plan/bootstrap.go
+++ b/pkg/plan/bootstrap.go
@@ -119,6 +119,21 @@ func (p *plan) addInstructions(cfg *config.Config, dataDir string) error {
 		return err
 	}
 
+	// Since Rancher v2.15.0, tls-internal-cn-allowed-services is needed to be
+	// configured properly to prevent TLS certificate flapping
+	// https://github.com/harvester/harvester/issues/11338
+	if semver.Compare(cfg.RancherVersion, "v2.15.0") >= 0 {
+		if err := p.addInstruction(rancher.ToApplyTlsInternalCnAllowedSettingInstruction(k8sVersion, dataDir)); err != nil {
+			return err
+		}
+		if err := p.addInstruction(rancher.ToRestartRancherInstruction(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
+			return err
+		}
+		if err := p.addInstruction(rancher.ToWaitRancherInstruction(cfg.RancherInstallerImage, cfg.SystemDefaultRegistry, k8sVersion)); err != nil {
+			return err
+		}
+	}
+
 	// If clusterrepo check fails, it waits 5 minutes and retries.
 	// Install harvester-cluster-repo deployment before clusterrepo,
 	// so we can avoid the 5 minutes waiting time.
@@ -217,6 +232,11 @@ func (p *plan) addFiles(cfg *config.Config, dataDir string) error {
 
 	// bootstrap manifests
 	if err := p.addFile(resources.ToBootstrapFile(cfg, resources.GetBootstrapManifests(dataDir))); err != nil {
+		return err
+	}
+
+	// tls-internal-cn-allowed-services manifests
+	if err := p.addFile(rancher.ToTlsInternalCnAllowedSettingFile(cfg, dataDir)); err != nil {
 		return err
 	}
 

--- a/pkg/rancher/run.go
+++ b/pkg/rancher/run.go
@@ -7,6 +7,8 @@ import (
 	"github.com/harvester/rancherd/pkg/config"
 	"github.com/harvester/rancherd/pkg/images"
 	"github.com/harvester/rancherd/pkg/kubectl"
+	"github.com/harvester/rancherd/pkg/resources"
+	v1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/system-agent/pkg/applyinator"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	"sigs.k8s.io/yaml"
@@ -27,6 +29,10 @@ func GetRancherValues(dataDir string) string {
 	return fmt.Sprintf("%s/rancher/values.yaml", dataDir)
 }
 
+func GetTlsInternalCnAllowedSetting(dataDir string) string {
+	return fmt.Sprintf("%s/bootstrapmanifests/tls-internal-cn-allowed-setting.yaml", dataDir)
+}
+
 func ToFile(cfg *config.Config, dataDir string) (*applyinator.File, error) {
 	values := data.MergeMaps(defaultValues, map[string]interface{}{
 		"systemDefaultRegistry": cfg.SystemDefaultRegistry,
@@ -42,6 +48,26 @@ func ToFile(cfg *config.Config, dataDir string) (*applyinator.File, error) {
 		Content: base64.StdEncoding.EncodeToString(data),
 		Path:    GetRancherValues(dataDir),
 	}, nil
+}
+
+func ToTlsInternalCnAllowedSettingFile(cfg *config.Config, dataDir string) (*applyinator.File, error) {
+	path := GetTlsInternalCnAllowedSetting(dataDir)
+	rs := []v1.GenericMap{
+		{
+			Data: map[string]interface{}{
+				"apiVersion": "management.cattle.io/v3",
+				"kind":       "Setting",
+				"metadata": map[string]interface{}{
+					"name": "tls-internal-cn-allowed-services",
+				},
+				"customized": false,
+				"default":    "",
+				"source":     "",
+				"value":      "kube-system/rke2-traefik",
+			},
+		},
+	}
+	return resources.ToFile(rs, path)
 }
 
 func ToInstruction(imageOverride, systemDefaultRegistry, k8sVersion, rancherVersion, dataDir string) (*applyinator.OneTimeInstruction, error) {

--- a/pkg/rancher/wait.go
+++ b/pkg/rancher/wait.go
@@ -10,6 +10,20 @@ import (
 	"github.com/harvester/rancherd/pkg/self"
 )
 
+func ToRestartRancherInstruction(_, _, k8sVersion string) (*applyinator.OneTimeInstruction, error) {
+	cmd, err := self.Self()
+	if err != nil {
+		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
+	}
+	instruction := &applyinator.OneTimeInstruction{}
+	instruction.Name = "restart-rancher"
+	instruction.SaveOutput = true
+	instruction.Args = []string{"retry", kubectl.Command(k8sVersion), "-n", "cattle-system", "rollout", "restart", "deploy/rancher"}
+	instruction.Env = kubectl.Env(k8sVersion)
+	instruction.Command = cmd
+	return instruction, nil
+}
+
 func ToWaitRancherInstruction(_, _, k8sVersion string) (*applyinator.OneTimeInstruction, error) {
 	cmd, err := self.Self()
 	if err != nil {
@@ -91,6 +105,21 @@ func ToCreateStvAggregationSecret(k8sVersion string) (*applyinator.OneTimeInstru
 	instruction.Name = "create-stv-aggregation-secret"
 	instruction.SaveOutput = true
 	instruction.Args = []string{"retry", kubectl.Command(k8sVersion), "create", "secret", "generic", "-n", "cattle-system", "stv-aggregation"}
+	instruction.Env = kubectl.Env(k8sVersion)
+	instruction.Command = cmd
+	return instruction, nil
+}
+
+func ToApplyTlsInternalCnAllowedSettingInstruction(k8sVersion, dataDir string) (*applyinator.OneTimeInstruction, error) {
+	path := GetTlsInternalCnAllowedSetting(dataDir)
+	cmd, err := self.Self()
+	if err != nil {
+		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
+	}
+	instruction := &applyinator.OneTimeInstruction{}
+	instruction.Name = "apply-tls-internal-cn-allowed-setting"
+	instruction.SaveOutput = true
+	instruction.Args = []string{"retry", kubectl.Command(k8sVersion), "apply", "--validate=false", "-f", path}
 	instruction.Env = kubectl.Env(k8sVersion)
 	instruction.Command = cmd
 	return instruction, nil


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

To address TLS certificate flapping in the fresh installation path when emebedded Rancher is v2.15.0

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Fresh Installation Path:

> 1. rancherd bring up Rancher v2.15.0
> 1. rancherd set `kube-system/traefik` to `tls-internal-cn-allowed-services` and rollout restart Rancher before applying Harvester managedchart


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11338

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

Related PR: https://github.com/harvester/harvester/pull/11341
