### PR TITLE
fix: hmac check improvement

### DIFF
--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -51,9 +51,7 @@ func get(server, token, path string, clusterToken bool) ([]byte, string, error) 
 	}
 	u.Path = path
 
-	var (
-		isTPM bool
-	)
+	var isTPM bool
 	if !clusterToken {
 		isTPM, token, err = tpm.ResolveToken(token)
 		if err != nil {
@@ -166,6 +164,10 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 			hash(token, nonce, data))
 	}
 
+	if err := checkHMACHeader(resp.Header.Get("X-Cattle-Hash"), token, nonce, data); err != nil {
+		return nil, "", err
+	}
+
 	if len(data) == 0 {
 		return nil, "", nil
 	}
@@ -184,6 +186,28 @@ func cacertsResponseError(statusCode int, status string, data []byte) error {
 			data)
 	}
 	return fmt.Errorf("response %d: %s getting cacerts: %s", statusCode, status, data)
+}
+
+func checkHMACHeader(HMACHeader string, token string, nonce string, data []byte) error {
+	// Since rancher v2.15.0, an authentication failure or empty token results in an empty HMAC header
+	if HMACHeader == "" {
+		return fmt.Errorf(
+			"missing HMAC header in server response: likely token mismatch or incorrect server URL; "+
+				"verify the provided token matches the token on the server node; "+
+				"check token configuration in %s or %s",
+			rke2NodeTokenPath, rancherdConfigPath,
+		)
+	}
+
+	expected := hash(token, nonce, data)
+	if HMACHeader != expected {
+		return fmt.Errorf("HMAC header verification failed: got %s, expected %s; "+
+			"if token configuration is correct, the response may have been tampered with; "+
+			"check token configuration in %s or %s",
+			HMACHeader, expected, rke2NodeTokenPath, rancherdConfigPath)
+	}
+
+	return nil
 }
 
 func ToUpdateCACertificatesInstruction() (*applyinator.OneTimeInstruction, error) {

--- a/pkg/cacerts/cacerts.go
+++ b/pkg/cacerts/cacerts.go
@@ -158,12 +158,6 @@ func CACerts(server, token string, clusterToken bool) ([]byte, string, error) {
 		return nil, "", cacertsResponseError(resp.StatusCode, resp.Status, data)
 	}
 
-	if resp.Header.Get("X-Cattle-Hash") != hash(token, nonce, data) {
-		return nil, "", fmt.Errorf("response hash (%s) does not match (%s)",
-			resp.Header.Get("X-Cattle-Hash"),
-			hash(token, nonce, data))
-	}
-
 	if err := checkHMACHeader(resp.Header.Get("X-Cattle-Hash"), token, nonce, data); err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
- from v2.15.0, when token is not match / empty, will not provide 502 anymore
- we keep 502 setting for Harvester pre-v1.9.x user

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- checkHMACHeader to ensure the new error message in 1.9.x is able to read properly

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10685

#### Test plan:

1. Get real token from node01: cat /var/lib/rancher/rke2/server/node-token → use part after last :
2. Join node02 with wrong token
3. See: likely token mismatch or incorrect server URL  in the log
```
failed to get cacerts (HTTP 502 Bad Gateway): likely token mismatch or incorrect server URL; verify the provided token matches /var/lib/rancher/rke2/server/node-token on the server node; check token configuration in /oem/90_custom.yaml or /etc/rancher/rancherd/config.yaml; response: Bad Gateway"
```

#### For older rancher. ~2.14.3
<img width="684" height="641" alt="Screenshot 2026-08-11 at 6 24 29 PM" src="https://github.com/user-attachments/assets/0386c7ba-2193-4258-bc4f-5c384df1cd5d" />

#### For newer rancher 2.14.4+
<img width="1292" height="545" alt="Screenshot 2026-08-12 at 11 46 41 AM" src="https://github.com/user-attachments/assets/837cac5a-36f8-4c43-bcad-f7de32a1133f" />

#### Additional documentation or context
